### PR TITLE
Fix: Prevent edit window from jumping when typing

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -261,10 +261,12 @@ impl NetworkMonitorApp {
             let mut is_open = true;
             let mut close_window = false;
             let mut form = self.editing_node.as_ref().unwrap().1.clone();
-            Window::new(format!("Edit Node: {}", form.name))
+            Window::new("Edit Node")
                 .open(&mut is_open)
                 .resizable(true)
                 .show(ctx, |ui| {
+                    ui.heading(format!("Editing: {}", form.name));
+                    ui.separator();
                     self.node_form_ui(ui, &mut form);
                     if ui.button("Save").clicked() {
                         self.update_node_from_form(node_id, &form.clone());


### PR DESCRIPTION
## Summary
- Fixed issue where the edit window would jump around the screen on every keystroke
- Changed from dynamic window title that updates with node name to static title
- Now displays the node name inside the window content instead

## Problem
When editing a node after creation, every click or keystroke caused the window to jump around the screen. This occurred because the window title was dynamically changing with the node name (`format!("Edit Node: {}", form.name)`), causing egui to treat it as a new window each frame and reset its position.

## Solution
Used a static window title ("Edit Node") and displayed the node name as a heading inside the window content instead. This ensures the window maintains its position and size throughout the editing session.

## Test plan
- [x] Build the application with `cargo run`
- [x] Create a new node
- [x] Click "Edit" on the node
- [x] Type in the name field and verify the window stays in place
- [x] Click in different fields and verify no jumping occurs

🤖 Generated with [Claude Code](https://claude.ai/code)