### PR TITLE
fix: add minimal permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/casey-mccarthy/net-monitor/security/code-scanning/6](https://github.com/casey-mccarthy/net-monitor/security/code-scanning/6)

To fix this issue, add a `permissions:` block at the workflow root (top level, alongside `name:`, `on:`, and `env:` etc). Use the minimal privilege required, which in this case is very likely `contents: read`, since the workflow appears only to check out code, build, test, and perform audits—no steps require writing GitHub repository state. Placing the block at the root applies it to all jobs, unless overridden at a lower level. No changes appear needed inside individual jobs.

#### Steps:
- Insert the following at line 2 (after `name: CI`):  
  ```yaml
  permissions:
    contents: read
  ```
- Verify that the indentation matches other top-level keys.

**No imports or additional definitions are needed. This is a pure YAML edit to one file.**


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
