### PR TITLE
fix: Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/casey-mccarthy/net-monitor/security/code-scanning/7](https://github.com/casey-mccarthy/net-monitor/security/code-scanning/7)

To fix the issue, add a `permissions` block either at the workflow root (recommended for consistency) or at each job (only if jobs need significantly different scopes). The minimal required permission for most jobs is `contents: read` (the least privilege for source access), unless a specific job requires more. In this workflow, none of the visible jobs need elevated permissions (no deployments, PR updates, releases), so root-level `contents: read` is appropriate. The explicit block should be added immediately after the `name: CI` line and before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
