### PR TITLE
feat: add color coding to status history fields (closes #39)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1357,11 +1357,24 @@ impl NetworkMonitorTui {
                         .map(format_duration)
                         .unwrap_or_else(|| "N/A".to_string());
 
+                    // Color-code status fields
+                    let from_color = match change.from_status {
+                        NodeStatus::Online => Color::Green,
+                        NodeStatus::Offline => Color::Red,
+                    };
+
+                    let to_color = match change.to_status {
+                        NodeStatus::Online => Color::Green,
+                        NodeStatus::Offline => Color::Red,
+                    };
+
                     Row::new(vec![
-                        timestamp,
-                        change.from_status.to_string(),
-                        change.to_status.to_string(),
-                        duration,
+                        Cell::from(timestamp),
+                        Cell::from(change.from_status.to_string())
+                            .style(Style::default().fg(from_color)),
+                        Cell::from(change.to_status.to_string())
+                            .style(Style::default().fg(to_color)),
+                        Cell::from(duration),
                     ])
                 })
                 .collect();


### PR DESCRIPTION
## Summary
- Adds visual color coding to status fields in the history view
- Online status displayed in green
- Offline status displayed in red
- Improves readability and quick visual scanning of status changes

## Changes
- Modified history table row generation to use colored Cell components
- Added color mapping: Online → Green, Offline → Red
- Applied colors to both "From" and "To" status columns

## Test plan
- [x] View status history with multiple Online/Offline transitions
- [x] Verify Online statuses display in green
- [x] Verify Offline statuses display in red
- [x] Check that colors improve readability

🤖 Generated with [Claude Code](https://claude.com/claude-code)