### PR TITLE
fix: move refresh icon to end of last check field (closes #40)

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -606,7 +606,7 @@ impl NetworkMonitorTui {
 
                 // Add pulsing indicator when check just occurred
                 let last_check_display = if flash_intensity > 0.0 {
-                    format!("⟳ {}", last_check)
+                    format!("{} ⟳", last_check)
                 } else {
                     last_check
                 };


### PR DESCRIPTION
## Summary
- Repositions the pulsing refresh icon (⟳) to appear after the timestamp instead of before
- Improves readability by keeping timestamp format consistent
- Better visual flow with icon serving as an indicator rather than prefix

## Changes
- Changed format from `⟳ HH:MM:SS` to `HH:MM:SS ⟳`
- Icon placement now emphasizes the timestamp rather than obscuring it

## Test plan
- [x] Trigger a status check and observe the refresh icon
- [x] Verify icon appears after the timestamp
- [x] Confirm pulsing animation still works correctly
- [x] Check that timestamp remains readable during animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)