### PR TITLE
fix: eliminate delay when closing SSH terminal windows (closes #46)

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,7 @@
 use crate::credentials::{CredentialStore, SshCredential};
 use anyhow::{anyhow, Result};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tracing::{error, info, warn};
 
 /// Trait defining the connection strategy interface
@@ -217,6 +217,9 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
             Command::new("osascript")
                 .arg("-e")
                 .arg(&script)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .spawn()
                 .map_err(|e| {
                     error!("Failed to open Terminal for SSH: {}", e);
@@ -233,6 +236,9 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
                 .arg("cmd")
                 .arg("/k")
                 .arg(&ssh_command_str)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .spawn();
 
             if result.is_err() {
@@ -243,6 +249,9 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
                     .arg("cmd")
                     .arg("/k")
                     .arg(&ssh_command_str)
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .spawn()
                     .map_err(|e| {
                         error!("Failed to open terminal for SSH: {}", e);
@@ -277,6 +286,10 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
                 } else {
                     cmd.arg(&ssh_command_str);
                 }
+
+                cmd.stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null());
 
                 if cmd.spawn().is_ok() {
                     success = true;


### PR DESCRIPTION
## Summary
- Fixes delay/hang when closing SSH terminal windows spawned by the application
- Redirects stdin, stdout, and stderr to null for all spawned terminal processes
- Ensures parent process doesn't wait for child terminal I/O
- Applies fix across all platforms (macOS, Windows, Linux)

## Changes
- Added `Stdio::null()` for stdin, stdout, and stderr in macOS Terminal.app spawn
- Added `Stdio::null()` for stdin, stdout, and stderr in Windows cmd.exe spawn (both primary and fallback)
- Added `Stdio::null()` for stdin, stdout, and stderr in Linux terminal emulator spawns

## Technical Details
Without these redirections, the parent process can block waiting for I/O from the spawned terminal, causing the application to hang until the terminal is closed. By redirecting to null, the spawned process is fully detached.

## Test plan
- [x] Test SSH connection on macOS - verify no delay when closing terminal
- [x] Test SSH connection on Windows - verify no delay when closing cmd window
- [x] Test SSH connection on Linux - verify no delay when closing terminal
- [x] Verify SSH functionality still works correctly on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)