### PR TITLE
fix: eliminate delay when closing SSH terminal windows

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,7 +1,7 @@
 use crate::credentials::{CredentialStore, SshCredential};
 use anyhow::{anyhow, Result};
 use std::net::{TcpStream, ToSocketAddrs};
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tracing::{error, info, warn};
 
 /// Trait defining the connection strategy interface
@@ -217,6 +217,9 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
             Command::new("osascript")
                 .arg("-e")
                 .arg(&script)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .spawn()
                 .map_err(|e| {
                     error!("Failed to open Terminal for SSH: {}", e);
@@ -233,6 +236,9 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
                 .arg("cmd")
                 .arg("/k")
                 .arg(&ssh_command_str)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
                 .spawn();
 
             if result.is_err() {
@@ -243,6 +249,9 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
                     .arg("cmd")
                     .arg("/k")
                     .arg(&ssh_command_str)
+                    .stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .spawn()
                     .map_err(|e| {
                         error!("Failed to open terminal for SSH: {}", e);
@@ -277,6 +286,10 @@ impl AuthenticatedConnectionStrategy for SshConnectionStrategy {
                 } else {
                     cmd.arg(&ssh_command_str);
                 }
+
+                cmd.stdin(Stdio::null())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null());
 
                 if cmd.spawn().is_ok() {
                     success = true;


### PR DESCRIPTION
## Summary

Eliminates the delay when closing SSH terminal windows by redirecting stdio streams to null when spawning terminal processes.

## Changes in this PR

### Bug Fixes
- fix: eliminate delay when closing SSH terminal windows

## Details

When spawning SSH terminal windows (via Terminal.app on macOS, cmd.exe on Windows, or various terminal emulators on Linux), the parent process was maintaining open file descriptors for stdin, stdout, and stderr. This caused the terminal windows to hang briefly when closing because the shell was waiting for these streams to close.

This PR adds `Stdio::null()` redirects for all three streams on all platforms:
- macOS (osascript with Terminal.app)
- Windows (cmd.exe with fallback)
- Linux (gnome-terminal, konsole, xterm)

## Test plan

- [x] Code compiles successfully
- [x] All unit tests pass (109 tests)
- [x] Clippy checks pass with no warnings
- [x] Security audit passes
- [ ] Manual testing: Open SSH connection via GUI and verify terminal closes immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>