### PR TITLE
docs: improve pre-commit check instructions to prevent CI formatting failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,13 @@ Note: The project uses `.cargo/audit.toml` to ignore known vulnerabilities that 
 
 When making changes:
 1. Run `cargo fmt` to format code
-2. Run `RUSTFLAGS="-A dead_code" cargo test --all-features` to test
-3. Run `RUSTFLAGS="-A dead_code" cargo clippy --all-targets --all-features -- -D warnings` for linting
-4. Run `RUSTFLAGS="-A dead_code" cargo build --release` for final build
+2. **IMPORTANT:** Commit formatting changes if any were made: `git add -A && git commit -m "style: apply formatting"`
+3. Run `cargo fmt -- --check` to verify formatting
+4. Run `RUSTFLAGS="-A dead_code" cargo test --all-features` to test
+5. Run `RUSTFLAGS="-A dead_code" cargo clippy --all-targets --all-features -- -D warnings` for linting
+6. Run `RUSTFLAGS="-A dead_code" cargo build --release` for final build
+
+**⚠️ KEY POINT:** Always commit formatting changes immediately after running `cargo fmt`. Never push code with uncommitted formatting changes, as this will cause CI failures.
 
 ## Git Workflow
 
@@ -129,27 +133,38 @@ Before pushing to remote and creating a PR, run these checks locally:
 # 1. Apply formatting
 cargo fmt
 
-# 2. Check formatting (verify no changes needed)
+# 2. Check if formatting made any changes and commit them
+if ! git diff --quiet; then
+    git add -A
+    git commit -m "style: apply cargo fmt formatting fixes"
+fi
+
+# 3. Verify formatting is correct (should pass now)
 cargo fmt -- --check
 
-# 3. Run tests
+# 4. Run tests
 RUSTFLAGS="-A dead_code" cargo test --all-features
 
-# 4. Run clippy
+# 5. Run clippy
 RUSTFLAGS="-A dead_code" cargo clippy --all-targets --all-features -- -D warnings
 
-# 5. Run integration tests
+# 6. Run integration tests
 RUSTFLAGS="-A dead_code" cargo test --test integration_tests
 ```
 
 **All-in-One Pre-Push Check:**
 ```bash
 cargo fmt && \
+(git diff --quiet || (git add -A && git commit -m "style: apply cargo fmt formatting fixes")) && \
 cargo fmt -- --check && \
 RUSTFLAGS="-A dead_code" cargo test --all-features && \
 RUSTFLAGS="-A dead_code" cargo clippy --all-targets --all-features -- -D warnings && \
 RUSTFLAGS="-A dead_code" cargo test --test integration_tests
 ```
+
+**⚠️ CRITICAL: Always commit formatting changes before pushing!**
+
+If `cargo fmt` makes any changes to your code, those changes MUST be committed before pushing and creating a PR. Otherwise, CI formatting checks will fail. The commands above automatically handle this.
 
 #### 4. Rebase on Main Before PR
 ```bash


### PR DESCRIPTION
## Summary

Updates `CLAUDE.md` with more robust pre-commit check instructions that automatically commit formatting changes before pushing, preventing CI formatting failures.

## Problem

The previous pre-commit check workflow had a critical flaw:

```bash
cargo fmt              # Apply formatting
cargo fmt -- --check   # Verify (always passes after applying!)
# ... but formatting changes not committed!
git push               # Push without formatting changes
# CI fails! ❌
```

This caused **PRs #57 and #58** to have failing CI formatting checks, despite passing locally.

### Root Cause

Feature branches created before PR #56 (formatting fix) merged contained unformatted code. Running `cargo fmt` locally applied formatting, but those changes weren't committed before pushing. CI then detected the uncommitted formatting differences and failed.

## Solution

Added automatic detection and committing of formatting changes:

```bash
# 1. Apply formatting
cargo fmt

# 2. Check if formatting made any changes and commit them
if ! git diff --quiet; then
    git add -A
    git commit -m "style: apply cargo fmt formatting fixes"
fi

# 3. Verify formatting is correct (should pass now)
cargo fmt -- --check
```

## Changes Made

### Development Workflow Section

**Before:**
- Simple list without emphasis on committing formatting

**After:**
- Explicit step: "Commit formatting changes if any were made"
- Added ⚠️ warning callout
- Clear guidance on when and why to commit

### Pre-Push Checks Section

**Before:**
```bash
cargo fmt && \
cargo fmt -- --check && \
# ... other checks
```

**After:**
```bash
cargo fmt && \
(git diff --quiet || (git add -A && git commit -m "style: apply cargo fmt formatting fixes")) && \
cargo fmt -- --check && \
# ... other checks
```

**Key Addition:** Automatic commit of formatting changes between apply and verify steps.

### New Documentation Features

1. **Git Diff Check**: Detects if `cargo fmt` made any changes
2. **Auto-Commit**: Commits changes automatically with proper message
3. **Critical Warning**: Highlighted callout about committing formatting
4. **Step-by-Step Clarity**: Numbered steps with explanations

## Benefits

✅ **Prevents CI Failures**: Formatting changes committed before push
✅ **Faster Feedback**: Catches issues locally, not in CI
✅ **Foolproof Workflow**: Single command does the right thing
✅ **Clearer Instructions**: Explicit about when/why to commit
✅ **Matches CI Behavior**: Local checks now mirror CI checks

## Impact

### Fixes Applied
- ✅ Fixed PR #57 formatting failures
- ✅ Fixed PR #58 formatting failures

### Future Prevention
This documentation update ensures Claude Code and developers:
- Always commit formatting changes immediately
- Never push with uncommitted formatting
- Run pre-commit checks that match CI behavior

## Testing

Verified the new workflow catches formatting issues:

```bash
# Make code changes without formatting
echo "fn test() {return 42;}" >> src/lib.rs

# Run new pre-commit workflow
cargo fmt && \
(git diff --quiet || (git add -A && git commit -m "style: apply formatting")) && \
cargo fmt -- --check

# Result: Formatting applied and committed automatically ✅
```

## Type of Change

- [x] **Documentation** - Improves developer workflow instructions

## Breaking Changes

None - this only updates documentation, not code behavior.

## Additional Context

### Why This Matters

Formatting checks are the first CI gate. Failing them:
- Blocks PR progress
- Requires additional commits
- Slows down review cycle
- Can be easily prevented with proper workflow

### Best Practices Enforced

1. **Commit early, commit often**: Formatting changes committed immediately
2. **Verify before push**: Format check confirms cleanliness
3. **Automation over memory**: Script handles the right flow
4. **CI parity**: Local checks match remote checks

---

### Review Timing Guidelines
⏱️ **Documentation PR**: Can be merged quickly after review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>