### PR TITLE
fix(tui): reset latency display for offline devices

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -867,15 +867,23 @@ impl NetworkMonitorTui {
                             .add_modifier(Modifier::BOLD),
                     )),
                     Cell::from(Span::styled(
-                        match node.response_time {
-                            Some(ms) => format!("{}ms", ms),
-                            None => "—".to_string(),
+                        if node.status == NodeStatus::Offline {
+                            "—".to_string()
+                        } else {
+                            match node.response_time {
+                                Some(ms) => format!("{}ms", ms),
+                                None => "—".to_string(),
+                            }
                         },
-                        Style::default().fg(match node.response_time {
-                            Some(ms) if ms < 100 => Color::Green,
-                            Some(ms) if ms < 300 => Color::Yellow,
-                            Some(_) => Color::Red,
-                            None => Color::DarkGray,
+                        Style::default().fg(if node.status == NodeStatus::Offline {
+                            Color::DarkGray
+                        } else {
+                            match node.response_time {
+                                Some(ms) if ms < 100 => Color::Green,
+                                Some(ms) if ms < 300 => Color::Yellow,
+                                Some(_) => Color::Red,
+                                None => Color::DarkGray,
+                            }
                         }),
                     )),
                     Cell::from(Span::styled(


### PR DESCRIPTION
## Summary

- When a device goes offline, the latency column now displays "—" in dark gray instead of the stale last-measured response time
- Previously, offline devices showed the timeout duration (e.g., 30000ms), making them look like they were responding slowly rather than being unreachable
- Display-only change in `src/tui.rs` — no data model or monitoring engine changes

## Changes in this PR

### 🐛 Bug Fixes
- **fix(tui):** Reset latency cell to "—" when `node.status == NodeStatus::Offline`, regardless of the `response_time` value. Degraded and Online nodes continue showing their actual latency with existing color coding.

## Test plan

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes with no warnings
- [x] All unit tests pass (94/94)
- [x] All integration tests pass
- [x] Release build succeeds
- [ ] Manual test: add an unreachable device, confirm latency column shows "—" once it transitions to Offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)